### PR TITLE
feat(claude): add update-docs skill for documentation maintenance

### DIFF
--- a/.claude/skills/update-docs/SKILL.md
+++ b/.claude/skills/update-docs/SKILL.md
@@ -1,0 +1,305 @@
+---
+name: update-docs
+description: >
+  This skill should be used when the user asks to "update documentation for my changes",
+  "check docs for this PR", "what docs need updating", "sync docs with code",
+  "scaffold docs for this feature", "document this feature", "review docs completeness",
+  "add docs for this change", "what documentation is affected", "docs impact",
+  or mentions "docs/public", "docs/contributors", "docs/internal", ".adr/",
+  "documentation update", "API reference", "MCP docs", "tech debt doc".
+  Provides guided workflow for updating Cronicorn documentation based on code changes.
+---
+
+# Update Documentation Skill
+
+Guided workflow for keeping Cronicorn documentation in sync with code changes. Covers public user docs, contributor docs, ADRs, and tech debt logging.
+
+## Quick Start
+
+1. **Analyze** — Identify which files changed (`git diff`)
+2. **Map** — Use CODE-TO-DOCS-MAPPING to find affected docs
+3. **Review** — Read existing docs to understand current state
+4. **Update** — Propose changes and wait for user confirmation
+5. **Validate** — Run `pnpm lint` and verify frontmatter
+6. **Commit** — Use conventional commit format (`docs(scope): ...`)
+
+---
+
+## Workflow A: Analyze Code Changes
+
+### Step 1: Identify Changed Files
+
+```bash
+# Compare against main branch
+git diff main...HEAD --stat
+
+# Or compare against a specific base
+git diff origin/main...HEAD --stat
+```
+
+### Step 2: Map Changes to Documentation
+
+Use the **CODE-TO-DOCS-MAPPING** reference (`.claude/skills/update-docs/references/CODE-TO-DOCS-MAPPING.md`) to identify which documentation files are affected.
+
+**Key mapping rules:**
+- Domain logic changes (`packages/domain/`) → `docs/public/technical/` + `docs/public/core-concepts.md`
+- API route changes (`apps/api/src/routes/`) → `docs/public/api-reference.md`
+- Scheduler changes (`packages/worker-scheduler/`) → `docs/public/technical/how-scheduling-works.md`
+- AI planner changes (`packages/worker-ai-planner/`) → `docs/public/technical/how-ai-adaptation-works.md`
+- MCP server changes (`apps/mcp-server/`) → `docs/public/mcp-server.md`
+- Database schema changes (`packages/adapter-drizzle/src/schema/`) → `docs/contributors/workspace-structure.md` + relevant public docs
+- New packages or apps → `docs/contributors/workspace-structure.md`
+
+### Step 3: Check for Documentation Gaps
+
+After mapping, ask:
+- Are there new features without user-facing documentation?
+- Are there new API endpoints missing from the API reference?
+- Are there architectural changes that need an ADR?
+- Is there tech debt that needs logging in `docs/_RUNNING_TECH_DEBT.md`?
+
+---
+
+## Workflow B: Update Existing Documentation
+
+### Step 1: Read the Target Doc
+
+Read the full file to understand:
+- **Frontmatter** — id, title, description, tags, sidebar_position, mcp metadata
+- **Structure** — Headings, sections, examples
+- **Audience** — User-facing (`docs/public/`), contributor (`docs/contributors/`), or internal (`docs/internal/`)
+- **Related docs** — Links to other pages that might also need updating
+
+### Step 2: Identify What Needs Changing
+
+Common change types:
+- **New feature** — Add section describing the feature with examples
+- **Changed behavior** — Update existing section, mark old behavior if relevant
+- **New configuration** — Add to configuration docs and/or API reference
+- **Deprecation** — Mark as deprecated with migration guidance
+- **New API endpoint** — Add to `docs/public/api-reference.md`
+- **Bug fix** — Update troubleshooting if the bug was documented there
+
+### Step 3: Propose Changes
+
+**IMPORTANT:** Show the user what you plan to change and wait for confirmation before editing.
+
+Present:
+1. Which files will be modified
+2. Summary of changes per file
+3. Any new files that need to be created
+
+### Step 4: Apply Changes
+
+Follow the conventions in **DOC-CONVENTIONS** reference (`.claude/skills/update-docs/references/DOC-CONVENTIONS.md`):
+- Preserve existing frontmatter structure
+- Update `lastModified` date in MCP metadata
+- Maintain consistent heading hierarchy
+- Include code examples where appropriate
+- Keep the TL;DR pattern at the top of technical docs
+
+### Step 5: Validate
+
+```bash
+# Check for lint errors
+pnpm lint
+
+# Build docs to verify (if docs app is available)
+pnpm --filter @cronicorn/docs build
+```
+
+---
+
+## Workflow C: Scaffold New Documentation
+
+### Step 1: Determine Doc Type and Location
+
+| Doc type | Location | Template |
+|----------|----------|----------|
+| User-facing feature | `docs/public/` | Public Doc Template |
+| Technical deep-dive | `docs/public/technical/` | Technical Doc Template |
+| API reference section | `docs/public/api-reference.md` | (append to existing) |
+| Contributor guide | `docs/contributors/` | Contributor Doc Template |
+| Architecture decision | `.adr/` | ADR Template |
+| Tech debt item | `docs/_RUNNING_TECH_DEBT.md` | (append to existing) |
+
+### Step 2: Use the Appropriate Template
+
+#### Public Doc Template
+
+```markdown
+---
+id: <kebab-case-id>
+title: <Title>
+description: <One-line description>
+tags:
+  - user
+  - <topic-tag>
+sidebar_position: <number>
+mcp:
+  uri: file:///docs/<filename>.md
+  mimeType: text/markdown
+  priority: <0.0-1.0>
+  lastModified: <YYYY-MM-DDT00:00:00Z>
+---
+
+# <Title>
+
+**TL;DR:** <One-paragraph summary of the feature/concept.>
+
+---
+
+## Overview
+
+<What is this feature and why does it exist?>
+
+## How It Works
+
+<Step-by-step explanation with code examples>
+
+## Configuration
+
+<Available options with defaults>
+
+## Examples
+
+<Real-world usage examples>
+
+## Related
+
+- [Core Concepts](./core-concepts.md)
+- [API Reference](./api-reference.md)
+```
+
+#### Technical Doc Template
+
+```markdown
+---
+id: <kebab-case-id>
+title: <Title>
+description: <Technical description>
+tags: [assistant, technical, <topic>]
+sidebar_position: <number>
+mcp:
+  uri: file:///docs/technical/<filename>.md
+  mimeType: text/markdown
+  priority: <0.0-1.0>
+  lastModified: <YYYY-MM-DDT00:00:00Z>
+---
+
+# <Title>
+
+**TL;DR:** <Technical summary in 1-2 sentences.>
+
+---
+
+## The Big Picture
+
+<High-level explanation>
+
+## How It Works
+
+<Detailed technical explanation>
+
+## Implementation Details
+
+<Code-level details with examples>
+
+## Trade-offs
+
+<Design decisions and their consequences>
+```
+
+#### Contributor Doc Template
+
+```markdown
+# <Title>
+
+<Brief description of what this guide covers.>
+
+## Prerequisites
+
+<What the reader needs before following this guide>
+
+## Steps
+
+<Step-by-step instructions with commands>
+
+## Common Issues
+
+<Troubleshooting tips>
+```
+
+#### ADR Template
+
+```markdown
+# <Decision Title>
+
+**Date:** YYYY-MM-DD
+**Status:** Accepted
+
+## Context
+
+<Why did we need to make this decision?>
+
+## Decision
+
+<What did we decide and why?>
+
+## Consequences
+
+<What are the trade-offs?>
+
+## References
+
+<Related task IDs, other ADRs, docs>
+```
+
+### Step 3: Set Correct Metadata
+
+- **sidebar_position**: Check existing docs in the same directory for numbering
+- **MCP priority**: 0.95 for essential docs, 0.80-0.90 for reference, 0.50-0.70 for niche topics
+- **tags**: Always include audience (`user` or `assistant`) plus topic tags
+- **id**: Must be unique across all docs, use kebab-case
+
+### Step 4: Cross-Reference
+
+After creating a new doc:
+1. Add links from related existing docs
+2. Update `docs/public/introduction.md` if it's a major feature
+3. Update `docs/contributors/workspace-structure.md` if new packages/apps are involved
+4. Consider updating `docs/public/core-concepts.md` if new terminology is introduced
+
+---
+
+## Documentation Conventions (Quick Reference)
+
+Full conventions: `.claude/skills/update-docs/references/DOC-CONVENTIONS.md`
+
+- **File naming**: kebab-case (e.g., `how-scheduling-works.md`)
+- **Frontmatter**: Required for all `docs/public/` files
+- **TL;DR pattern**: Start technical docs with a bold TL;DR summary
+- **Code examples**: Use fenced code blocks with language identifiers
+- **Links**: Use relative paths (e.g., `./core-concepts.md`, `./technical/reference.md`)
+- **Headings**: H1 for page title, H2 for major sections, H3+ for subsections
+- **Tables**: Use for configuration options, API endpoints, comparison matrices
+
+---
+
+## Validation Checklist
+
+Before committing documentation changes:
+
+- [ ] Frontmatter is complete and valid (all `docs/public/` files)
+- [ ] `lastModified` date updated in MCP metadata
+- [ ] `id` is unique across all docs
+- [ ] All internal links are valid relative paths
+- [ ] Code examples are accurate and tested
+- [ ] TL;DR present for technical docs
+- [ ] Tags include audience indicator (`user` or `assistant`)
+- [ ] No broken markdown formatting
+- [ ] `pnpm lint` passes
+- [ ] New terminology added to `docs/public/core-concepts.md` if applicable
+- [ ] Tech debt logged in `docs/_RUNNING_TECH_DEBT.md` if shortcuts were taken
+- [ ] ADR created if this is an architectural decision
+- [ ] Commit uses `docs(scope): description` format

--- a/.claude/skills/update-docs/references/CODE-TO-DOCS-MAPPING.md
+++ b/.claude/skills/update-docs/references/CODE-TO-DOCS-MAPPING.md
@@ -1,0 +1,276 @@
+# Code-to-Docs Mapping
+
+Maps source code locations to the documentation files they affect. Use this reference when analyzing code changes to identify which docs need updating.
+
+---
+
+## Apps
+
+### `apps/api/` — HTTP API Server
+
+| Source path | Docs affected |
+|-------------|---------------|
+| `apps/api/src/routes/` | `docs/public/api-reference.md` |
+| `apps/api/src/routes/auth/` | `docs/public/api-reference.md` (Authentication section), `docs/contributors/authentication.md` |
+| `apps/api/src/routes/jobs/` | `docs/public/api-reference.md` (Jobs endpoints) |
+| `apps/api/src/routes/endpoints/` | `docs/public/api-reference.md` (Endpoints section) |
+| `apps/api/src/routes/runs/` | `docs/public/api-reference.md` (Runs section) |
+| `apps/api/src/index.ts` | `docs/contributors/workspace-structure.md` (composition root) |
+
+### `apps/web/` — Frontend Web App
+
+| Source path | Docs affected |
+|-------------|---------------|
+| `apps/web/src/routes/` | May affect `docs/public/quick-start.md` (UI screenshots/instructions) |
+| `apps/web/src/components/` | Rarely affects docs directly (UI internals) |
+
+### `apps/scheduler/` — Scheduler Worker App
+
+| Source path | Docs affected |
+|-------------|---------------|
+| `apps/scheduler/src/` | `docs/public/technical/system-architecture.md`, `docs/public/technical/how-scheduling-works.md` |
+| `apps/scheduler/src/index.ts` | `docs/contributors/workspace-structure.md` (composition root) |
+
+### `apps/ai-planner/` — AI Planner Worker App
+
+| Source path | Docs affected |
+|-------------|---------------|
+| `apps/ai-planner/src/` | `docs/public/technical/system-architecture.md`, `docs/public/technical/how-ai-adaptation-works.md` |
+| `apps/ai-planner/src/index.ts` | `docs/contributors/workspace-structure.md` (composition root) |
+
+### `apps/mcp-server/` — MCP Server
+
+| Source path | Docs affected |
+|-------------|---------------|
+| `apps/mcp-server/src/` | `docs/public/mcp-server.md` |
+| `apps/mcp-server/src/tools/` | `docs/public/mcp-server.md` (Available Tools section) |
+| `apps/mcp-server/src/resources/` | `docs/public/mcp-server.md` (Resources section) |
+| `apps/mcp-server/package.json` | `docs/public/mcp-server.md` (installation instructions, version) |
+
+### `apps/docs/` — Documentation Site
+
+| Source path | Docs affected |
+|-------------|---------------|
+| `apps/docs/` | Docusaurus config only; content lives in `docs/` |
+| `apps/docs/docusaurus.config.ts` | Sidebar structure, site metadata |
+
+### `apps/migrator/` — Database Migrator
+
+| Source path | Docs affected |
+|-------------|---------------|
+| `apps/migrator/src/` | `docs/contributors/quick-start.md` (database setup) |
+
+---
+
+## Packages — Domain & Core
+
+### `packages/domain/` — Pure Domain Logic
+
+| Source path | Docs affected |
+|-------------|---------------|
+| `packages/domain/src/scheduler.ts` | `docs/public/technical/how-scheduling-works.md` |
+| `packages/domain/src/governor.ts` (or governor logic) | `docs/public/technical/how-scheduling-works.md`, `docs/public/core-concepts.md` (Governor section) |
+| `packages/domain/src/ports/` | `docs/public/technical/system-architecture.md` (Ports section) |
+| `packages/domain/src/entities/` | `docs/public/core-concepts.md` (if new entity types) |
+| `packages/domain/src/policies/` | `docs/public/technical/configuration-and-constraints.md` |
+| Any new port interface | `docs/contributors/workspace-structure.md`, `docs/public/technical/system-architecture.md` |
+
+### `packages/services/` — Business Logic Layer
+
+| Source path | Docs affected |
+|-------------|---------------|
+| `packages/services/src/` | `docs/public/technical/system-architecture.md` (Services layer) |
+| Job management services | `docs/public/core-concepts.md`, `docs/public/api-reference.md` |
+| Scheduling services | `docs/public/technical/how-scheduling-works.md` |
+
+### `packages/api-contracts/` — API Contracts
+
+| Source path | Docs affected |
+|-------------|---------------|
+| `packages/api-contracts/src/` | `docs/public/api-reference.md` (request/response schemas) |
+| New route contracts | `docs/public/api-reference.md` (new endpoint documentation) |
+
+---
+
+## Packages — Adapters
+
+### `packages/adapter-drizzle/` — Database Adapter
+
+| Source path | Docs affected |
+|-------------|---------------|
+| `packages/adapter-drizzle/src/schema/` | `docs/contributors/workspace-structure.md`, may affect `docs/public/core-concepts.md` if data model changes |
+| `packages/adapter-drizzle/src/repos/` | `docs/contributors/workspace-structure.md` |
+| `packages/adapter-drizzle/src/migrations/` | `docs/contributors/quick-start.md` (migration instructions) |
+
+### `packages/adapter-ai/` — AI SDK Adapter
+
+| Source path | Docs affected |
+|-------------|---------------|
+| `packages/adapter-ai/src/` | `docs/public/technical/how-ai-adaptation-works.md` |
+
+### `packages/adapter-http/` — HTTP Dispatcher
+
+| Source path | Docs affected |
+|-------------|---------------|
+| `packages/adapter-http/src/` | `docs/public/technical/how-scheduling-works.md` (endpoint execution) |
+
+### `packages/adapter-cron/` — Cron Parser
+
+| Source path | Docs affected |
+|-------------|---------------|
+| `packages/adapter-cron/src/` | `docs/public/core-concepts.md` (schedule/cron expression section) |
+
+### `packages/adapter-stripe/` — Stripe Integration
+
+| Source path | Docs affected |
+|-------------|---------------|
+| `packages/adapter-stripe/src/` | `docs/public/` (pricing-related docs if they exist) |
+
+### `packages/adapter-pino/` — Logger
+
+| Source path | Docs affected |
+|-------------|---------------|
+| `packages/adapter-pino/src/` | `docs/contributors/` (logging conventions if documented) |
+
+### `packages/adapter-system-clock/` — System Clock
+
+| Source path | Docs affected |
+|-------------|---------------|
+| `packages/adapter-system-clock/src/` | Rarely affects docs (infrastructure detail) |
+
+---
+
+## Packages — Workers
+
+### `packages/worker-scheduler/` — Scheduler Worker Logic
+
+| Source path | Docs affected |
+|-------------|---------------|
+| `packages/worker-scheduler/src/` | `docs/public/technical/how-scheduling-works.md`, `docs/public/technical/system-architecture.md` |
+| Simulation logic | `docs/contributors/workspace-structure.md` (`pnpm sim`) |
+
+### `packages/worker-ai-planner/` — AI Planner Worker Logic
+
+| Source path | Docs affected |
+|-------------|---------------|
+| `packages/worker-ai-planner/src/` | `docs/public/technical/how-ai-adaptation-works.md`, `docs/public/technical/system-architecture.md` |
+| AI tool definitions | `docs/public/technical/how-ai-adaptation-works.md` |
+| Hint/nudge logic | `docs/public/core-concepts.md` (Hints section) |
+
+---
+
+## Packages — UI & Content
+
+### `packages/ui-library/` — Shared UI Components
+
+| Source path | Docs affected |
+|-------------|---------------|
+| `packages/ui-library/src/` | Rarely affects user docs (internal UI) |
+
+### `packages/content/` — Centralized Content
+
+| Source path | Docs affected |
+|-------------|---------------|
+| `packages/content/src/` | May affect multiple docs (brand, pricing, copy changes) |
+
+---
+
+## Configuration & Infrastructure
+
+| Source path | Docs affected |
+|-------------|---------------|
+| `.env` / `.env.example` | `docs/contributors/environment-configuration.md` |
+| `package.json` (root) | `docs/contributors/quick-start.md` (commands) |
+| `docker-compose.yml` | `docs/contributors/quick-start.md`, `docs/public/self-hosting.md` |
+| `drizzle.config.ts` | `docs/contributors/quick-start.md` (database section) |
+| `pnpm-workspace.yaml` | `docs/contributors/workspace-structure.md` |
+
+---
+
+## Documentation Files
+
+| Source path | Docs affected |
+|-------------|---------------|
+| `.adr/` | Cross-reference with relevant public/contributor docs |
+| `docs/_RUNNING_TECH_DEBT.md` | Standalone (no cross-references needed) |
+| `.claude/rules/` | `docs/contributors/` (if dev workflow changes) |
+| `.claude/CLAUDE.md` | Should stay in sync with `docs/contributors/workspace-structure.md` |
+
+---
+
+## Common Change Patterns
+
+### New API Endpoint
+
+1. Add route contract in `packages/api-contracts/`
+2. Implement route in `apps/api/src/routes/`
+3. **Docs**: Update `docs/public/api-reference.md` with new endpoint
+4. **Docs**: Update `docs/public/code-examples.md` if usage example is helpful
+
+### New Domain Entity or Concept
+
+1. Add entity/port in `packages/domain/`
+2. Add adapter in `packages/adapter-drizzle/`
+3. Add service in `packages/services/`
+4. **Docs**: Add to `docs/public/core-concepts.md`
+5. **Docs**: Update `docs/contributors/workspace-structure.md` if new package
+
+### New Scheduling Behavior
+
+1. Change domain logic in `packages/domain/`
+2. Update worker in `packages/worker-scheduler/`
+3. **Docs**: Update `docs/public/technical/how-scheduling-works.md`
+4. **Docs**: Update `docs/public/core-concepts.md` if new terminology
+5. **Docs**: Consider ADR if this is an architectural decision
+
+### New AI Feature
+
+1. Update AI adapter in `packages/adapter-ai/`
+2. Update planner in `packages/worker-ai-planner/`
+3. **Docs**: Update `docs/public/technical/how-ai-adaptation-works.md`
+4. **Docs**: Update `docs/public/core-concepts.md` if new concept
+5. **Docs**: Update `docs/public/use-cases.md` if new use case enabled
+
+### New MCP Tool
+
+1. Add tool in `apps/mcp-server/src/tools/`
+2. **Docs**: Update `docs/public/mcp-server.md` (Available Tools section)
+
+### New Package or App
+
+1. Create package/app in workspace
+2. **Docs**: Update `docs/contributors/workspace-structure.md`
+3. **Docs**: Update `.claude/CLAUDE.md` if it affects the project overview
+
+### Configuration Change
+
+1. Update `.env.example` or config loading
+2. **Docs**: Update `docs/contributors/environment-configuration.md`
+3. **Docs**: Update `docs/public/self-hosting.md` if user-facing
+4. **Docs**: Update `docs/public/technical/configuration-and-constraints.md` if constraint
+
+---
+
+## Quick Search Commands
+
+When you need to find docs related to a specific topic, use these search strategies:
+
+```bash
+# Find docs mentioning a specific feature
+Grep pattern="surge.detection" path="docs/"
+
+# Find all docs with specific tags
+Grep pattern="tags:.*scheduling" path="docs/public/"
+
+# Find docs referencing a specific package
+Grep pattern="adapter-drizzle\|DrizzleJobsRepo" path="docs/"
+
+# Find all API endpoint documentation
+Grep pattern="POST\|GET\|PUT\|DELETE\|PATCH" path="docs/public/api-reference.md"
+
+# Find all frontmatter with MCP metadata
+Grep pattern="^mcp:" path="docs/public/"
+
+# List all doc files sorted by modification time
+Glob pattern="docs/**/*.md"
+```

--- a/.claude/skills/update-docs/references/DOC-CONVENTIONS.md
+++ b/.claude/skills/update-docs/references/DOC-CONVENTIONS.md
@@ -1,0 +1,347 @@
+# Documentation Conventions
+
+Formatting and structural rules for all Cronicorn documentation.
+
+---
+
+## File Organization
+
+### Directory Structure
+
+```
+docs/
+├── _RUNNING_TECH_DEBT.md          # Mandatory tech debt log
+├── public/                         # User-facing documentation (Docusaurus)
+│   ├── introduction.md
+│   ├── quick-start.md
+│   ├── core-concepts.md
+│   ├── use-cases.md
+│   ├── recipes.md
+│   ├── code-examples.md
+│   ├── api-reference.md
+│   ├── mcp-server.md
+│   ├── self-hosting.md
+│   ├── automated-error-recovery.md
+│   ├── troubleshooting.md
+│   └── technical/                  # Deep-dive technical docs
+│       ├── system-architecture.md
+│       ├── how-scheduling-works.md
+│       ├── how-ai-adaptation-works.md
+│       ├── coordinating-multiple-endpoints.md
+│       ├── configuration-and-constraints.md
+│       └── reference.md
+├── contributors/                   # Developer/contributor docs
+│   ├── README.md
+│   ├── quick-start.md
+│   ├── workspace-structure.md
+│   ├── quality-checks.md
+│   ├── authentication.md
+│   └── environment-configuration.md
+└── internal/                       # Internal strategy, marketing, archive
+    ├── marketing/
+    ├── tasks/
+    └── archive/
+```
+
+### File Naming
+
+- **Always kebab-case**: `how-scheduling-works.md`, not `HowSchedulingWorks.md`
+- **Descriptive names**: Prefer `coordinating-multiple-endpoints.md` over `coordination.md`
+- **No numeric prefixes in filenames**: Use `sidebar_position` in frontmatter for ordering
+- **Extension**: Always `.md` (plain Markdown, not MDX)
+
+---
+
+## Frontmatter
+
+### Required for `docs/public/` Files
+
+Every public doc must have complete frontmatter:
+
+```yaml
+---
+id: core-concepts                          # Unique kebab-case identifier
+title: Core Concepts                       # Display title
+description: Key terminology for Cronicorn # One-line description (used in SEO/meta)
+tags:                                      # Categorization tags
+  - user                                   # Audience: user or assistant
+  - essential                              # Importance marker
+  - surge-detection                        # Topic tags
+sidebar_position: 2                        # Sort order in Docusaurus sidebar
+mcp:                                       # MCP Server metadata (for AI assistants)
+  uri: file:///docs/core-concepts.md       # File path for MCP resource
+  mimeType: text/markdown
+  priority: 0.95                           # AI importance: 0.0 (low) to 1.0 (high)
+  lastModified: 2026-02-06T00:00:00Z      # Last content update date
+---
+```
+
+### Frontmatter Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `id` | Yes | Unique identifier, kebab-case. Used as URL slug. |
+| `title` | Yes | Page title displayed in sidebar and heading |
+| `description` | Yes | One-line summary for SEO meta tags and MCP |
+| `tags` | Yes | Array of categorization tags |
+| `sidebar_position` | Yes | Numeric sort order in sidebar |
+| `mcp.uri` | Yes | File path for MCP resource serving |
+| `mcp.mimeType` | Yes | Always `text/markdown` |
+| `mcp.priority` | Yes | AI importance weight (0.0-1.0) |
+| `mcp.lastModified` | Yes | ISO 8601 date of last content update |
+| `slug` | No | Custom URL path (only used on introduction.md) |
+| `sidebar_label` | No | Alternate sidebar display name |
+| `displayed_sidebar` | No | Which sidebar to show |
+
+### MCP Priority Guidelines
+
+| Priority | When to use |
+|----------|-------------|
+| 0.95 | Essential docs: introduction, core-concepts, quick-start |
+| 0.90 | Key references: api-reference, mcp-server |
+| 0.80 | Technical deep-dives: system-architecture, scheduling |
+| 0.70 | Supplementary: recipes, use-cases, code-examples |
+| 0.50 | Niche or rarely-needed content |
+
+### Tag Conventions
+
+**Audience tags** (include at least one):
+- `user` — Written for end-users of Cronicorn
+- `assistant` — Written for AI assistants consuming via MCP
+
+**Importance tags:**
+- `essential` — Must-read for understanding Cronicorn
+
+**Topic tags** (include relevant ones):
+- `api`, `reference`, `technical`, `architecture`
+- `surge-detection`, `baseline-schedule`, `adaptive-scheduling`
+- `cross-job-coordination`, `response-body-parsing`
+- `degraded-state`, `monitoring-frequency`
+- `mcp`, `self-hosting`, `authentication`
+
+### Contributor and Internal Docs
+
+`docs/contributors/` and `docs/internal/` files do **not** require the full frontmatter. A simple H1 title is sufficient.
+
+---
+
+## Content Structure
+
+### TL;DR Pattern
+
+All `docs/public/technical/` docs start with a bold TL;DR after the H1:
+
+```markdown
+# System Architecture
+
+**TL;DR:** Cronicorn uses two independent workers (Scheduler and AI Planner)
+that communicate only through a shared database.
+
+---
+
+## The Big Picture
+```
+
+### Heading Hierarchy
+
+- **H1** (`#`) — Page title only (one per file, matches frontmatter `title`)
+- **H2** (`##`) — Major sections
+- **H3** (`###`) — Subsections
+- **H4** (`####`) — Rarely used, for deeply nested content
+
+Never skip heading levels (e.g., don't go from H2 to H4).
+
+### Section Ordering (Public Docs)
+
+Typical order for feature docs:
+1. TL;DR (for technical docs)
+2. Overview / What is this?
+3. How it works
+4. Configuration / Options
+5. Examples
+6. Related links
+
+### Horizontal Rules
+
+Use `---` to separate the TL;DR from the main content. Do not overuse horizontal rules elsewhere.
+
+---
+
+## Code Examples
+
+### Fenced Code Blocks
+
+Always specify the language:
+
+```markdown
+```bash
+curl -H "x-api-key: cron_abc123..." https://api.cronicorn.com/api/jobs
+```​
+
+```typescript
+const response = await fetch('/api/jobs', {
+  headers: { 'x-api-key': apiKey },
+});
+```​
+
+```json
+{
+  "id": "job_123",
+  "name": "Health Check",
+  "status": "active"
+}
+```​
+```
+
+### Code Block Languages
+
+Use these identifiers:
+- `bash` — Shell commands
+- `typescript` — TypeScript code
+- `json` — JSON payloads and responses
+- `yaml` — Configuration (rarely used)
+- `sql` — Database queries (rarely used)
+
+### Command Examples
+
+Show commands the user would actually run:
+
+```markdown
+```bash
+# Create a job via API
+curl -X POST https://api.cronicorn.com/api/jobs \
+  -H "x-api-key: cron_abc123..." \
+  -H "Content-Type: application/json" \
+  -d '{"name": "Health Check"}'
+```​
+```
+
+---
+
+## Links
+
+### Internal Links
+
+Use relative paths from the current file:
+
+```markdown
+<!-- From docs/public/quick-start.md -->
+See [Core Concepts](./core-concepts.md) for terminology.
+See [System Architecture](./technical/system-architecture.md) for details.
+
+<!-- From docs/public/technical/how-scheduling-works.md -->
+See [Core Concepts](../core-concepts.md) for terminology.
+```
+
+### External Links
+
+Use full URLs with descriptive text:
+
+```markdown
+See the [cron expression syntax](https://crontab.guru/) for help.
+```
+
+### Cross-Audience Links
+
+Avoid linking from `docs/public/` to `docs/contributors/` or `docs/internal/`. These audiences are separate.
+
+---
+
+## Tables
+
+Use Markdown tables for structured data:
+
+```markdown
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `name` | string | — | Job display name |
+| `status` | enum | `active` | One of: active, paused, archived |
+| `schedule` | string | — | Cron expression (e.g., `*/5 * * * *`) |
+```
+
+- Left-align all columns (default)
+- Use `—` for "no default" or "required"
+- Keep descriptions concise
+
+---
+
+## Writing Style
+
+### Voice
+
+- **Public docs**: Second person ("you"), instructional tone
+- **Technical docs**: Third person for system descriptions, second person for user actions
+- **Contributor docs**: Direct and pragmatic, assume developer audience
+
+### Clarity
+
+- Lead with the most important information
+- One idea per paragraph
+- Use lists for 3+ related items
+- Prefer concrete examples over abstract descriptions
+- Define new terms when first introduced
+
+### Terminology
+
+Use consistent terminology throughout:
+
+| Term | Usage |
+|------|-------|
+| Job | A container for related endpoints |
+| Endpoint | An HTTP request with a schedule |
+| Scheduler | The worker that executes endpoints |
+| AI Planner | The worker that analyzes and suggests |
+| Hint | A temporary AI scheduling suggestion |
+| Governor | The component that calculates next run times |
+| Baseline schedule | The user-defined cron expression |
+| Surge detection | AI identifying increased activity patterns |
+
+If introducing new terminology, add it to `docs/public/core-concepts.md`.
+
+---
+
+## ADR Conventions
+
+ADRs live in `.adr/` with numbered prefixes:
+
+- Format: `NNNN-meaningful-name.md` (e.g., `0064-new-feature.md`)
+- Check the highest existing number before creating a new one
+- Follow the template in `.claude/rules/20-adr-process.md`
+- Always include a `## References` section with task IDs
+
+---
+
+## Tech Debt Logging
+
+Any TODO, shortcut, or uncertainty MUST be logged in `docs/_RUNNING_TECH_DEBT.md`:
+
+```markdown
+## Feature: <Feature Name> (Implementation Date: YYYY-MM-DD)
+
+### Remaining Work
+- [ ] Task description
+
+### Technical Debt
+- Description of shortcut or suboptimal implementation
+
+### Uncertainties
+- Open question about requirements or design
+```
+
+See `.claude/rules/21-tech-debt-logging.md` for full requirements.
+
+---
+
+## Commit Messages for Docs
+
+Use conventional commit format:
+
+```
+docs(public): add surge detection guide
+docs(api): update authentication examples
+docs(contributors): add environment setup guide
+docs(adr): record decision on hint expiration policy
+docs(tech-debt): log missing validation in job creation
+```
+
+Scopes: `public`, `technical`, `api`, `contributors`, `adr`, `tech-debt`, `mcp`


### PR DESCRIPTION
Adds a Claude Code skill modeled after the Vercel Next.js update-docs pattern,
tailored to Cronicorn's doc structure. Includes three workflows (analyze, update,
scaffold) plus reference files for doc conventions and code-to-docs mapping.

https://claude.ai/code/session_01Q6FyoCYduQ1H8y9BDYsaX7