### PR TITLE
fix(web): replace tab bottom border with pill-style background

### DIFF
--- a/apps/web/src/components/splash-page/timeline/timeline-tabs.tsx
+++ b/apps/web/src/components/splash-page/timeline/timeline-tabs.tsx
@@ -34,10 +34,10 @@ export function TimelineTabs({ tabs, className, onTabChange }: AnimatedTabsProps
 
         <ScrollArea className="max-w-7xl mx-auto w-full">
           <div className="w-full relative">
-            <TabsList className="flex h-auto bg-transparent min-w-full p-0 gap-0 rounded-none border-b border-border/20">
+            <TabsList className="flex h-auto bg-muted/10 min-w-full p-1 gap-1 rounded-lg">
               {tabs.map(tab => (
                 <TabsTrigger
-                  className="relative rounded-none border-0 bg-transparent px-5 md:px-6 py-3.5 text-sm font-medium text-muted-foreground shadow-none transition-all duration-200 hover:text-foreground/90 data-[state=active]:bg-transparent! data-[state=active]:text-foreground data-[state=active]:shadow-none after:absolute after:bottom-0 after:left-0 after:right-0 after:h-0.5 after:bg-transparent data-[state=active]:after:bg-primary"
+                  className="rounded-md border-0 bg-transparent px-5 md:px-6 py-2.5 text-sm font-medium text-muted-foreground shadow-none transition-all duration-200 hover:text-foreground/90 hover:bg-muted/20 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm"
                   key={`${tab.label}-tab-trigger`}
                   value={tab.id}
                 >


### PR DESCRIPTION
The bottom border on the scenario tabs overlapped with the ScrollArea
scrollbar. Replaced the underline tab style with a pill-style treatment:
subtle muted background on the tab bar with rounded active-state
highlights, avoiding any border/scrollbar conflict.

https://claude.ai/code/session_01NGqMZT5jsbvTzEJZZah7La